### PR TITLE
SD fix

### DIFF
--- a/.github/workflows/esp32s3-build-master.yml
+++ b/.github/workflows/esp32s3-build-master.yml
@@ -25,7 +25,7 @@ on:
   push:
     branches: [main, master]
     paths:
-      - 'main/main.c'
+      - 'main/version.h'
       - '.github/scripts/**'
       - '.github/workflows/esp32s3-build-master.yml'
   release:
@@ -99,7 +99,7 @@ jobs:
           version=$(python - <<'PY'
           from pathlib import Path
           import re
-          text = Path("main/main.c").read_text()
+          text = Path("main/version.h").read_text()
           m = re.search(r'JANOS_ADV_VERSION\s*"([^"]+)"', text)
           if not m:
               raise SystemExit("JANOS_ADV_VERSION not found")

--- a/.github/workflows/esp32s3-build-only.yml
+++ b/.github/workflows/esp32s3-build-only.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main, master, development]
     paths:
-      - 'main/main.c'
+      - 'main/version.h'
       - '.github/scripts/**'
       - '.github/workflows/esp32s3-build-only.yml'
 


### PR DESCRIPTION
Fix SD detection race condition on cold boot and Version print
Monster may not have finished mounting the SD card when ADV immediately
sends sd_status after a successful ping. Added 1s boot delay, synchronous
block-wait with 3s timeout, and 2 retry attempts so transient no-response
cases don't silently skip the check.